### PR TITLE
Centered Loader (Taking in count the Sidebar)

### DIFF
--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -9,6 +9,7 @@ const override = css`
    justify-content: center;
    align-items: center;
    transform: translate(-10rem, -10rem);
+   margin-left: 22rem; // 22rem is the width of the sidebar, so it's not responsive
 `;
 
 const Loader = () => {


### PR DESCRIPTION
Used 22rem from the sidebar to move it to the right so now is centered, but 22rem is the width of the sidebar, so it's not responsive